### PR TITLE
Fix update setpoint function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix update setpoint shows wrong argument
+- Fix wrong data format in read product identifier
 
 ## [1.0.0] - 2024-4-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] 
 
+## [1.0.1] - 2025-1-07
+
+### Fixed
+
+- Fix update setpoint shows wrong argument
+
 ## [1.0.0] - 2024-4-22
 
 ### Added
 
 - Initial release
 
-[Unreleased]: https://github.com/Sensirion/python-i2c-sfx6xxx/compare/1.0.0...HEAD
+[Unreleased]: https://github.com/Sensirion/python-i2c-sfx6xxx/compare/1.0.1...HEAD
+[1.0.1]: https://github.com/Sensirion/python-i2c-sfx6xxx/compare/1.0.0...1.0.1
 [1.0.0]: https://github.com/Sensirion/python-i2c-sfx6xxx/releases/tag/1.0.0

--- a/sensirion_i2c_sfx6xxx/commands.py
+++ b/sensirion_i2c_sfx6xxx/commands.py
@@ -50,7 +50,7 @@ class ReadProductIdentifier(Transfer):
         return self.tx_data.pack([])
 
     tx = TxData(CMD_ID, '>H')
-    rx = RxData(descriptor='>I8B', convert_to_int=True)
+    rx = RxData(descriptor='>IQ', convert_to_int=True)
 
 
 class ResetPointerToMeasurementBuffer(Transfer):

--- a/sensirion_i2c_sfx6xxx/device.py
+++ b/sensirion_i2c_sfx6xxx/device.py
@@ -513,5 +513,5 @@ class Sfx6xxxDevice(Sfx6xxxDeviceBase):
             - Only applicable for SFC6xxx mass flow controllers.
         """
         raw_flow = SignalRawFlow(flow, self._flow_scale_factor, self._flow_offset)
-        self.sfx6xxx.update_setpoint(raw_flow)
+        self.sfx6xxx.update_setpoint(raw_flow.value)
         return self.sfx6xxx.reset_pointer_to_measurement_buffer()

--- a/sensirion_i2c_sfx6xxx/result_types.py
+++ b/sensirion_i2c_sfx6xxx/result_types.py
@@ -53,7 +53,7 @@ class SignalRawFlow(AbstractSignal):
     """This signal converts a user flow input from float into the twos-complement representation"""
 
     def __init__(self, flow, flow_scale_factor, flow_offset):
-        self._raw_flow = int(flow * flow_scale_factor) + flow_offset
+        self._raw_flow = int(flow * flow_scale_factor + flow_offset)
 
     @property
     def value(self):

--- a/sensirion_i2c_sfx6xxx/version.py
+++ b/sensirion_i2c_sfx6xxx/version.py
@@ -2,4 +2,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
 
-version = "1.0.0"
+version = "1.0.1"


### PR DESCRIPTION
A internally a wrong argument is provided to the update setpoint call, causing it to throw and exception instead of updating the setpoint.

This commit fixes this issue and updates the version and changelog for a 1.0.1 bugfix release.